### PR TITLE
Improve readability of atari speaks example code

### DIFF
--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -126,8 +126,7 @@ atariSpeaks atari rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
                           ( \(Tuple audio analyser) -> do
                               audio ffi2
                               for_ analyser \a -> do
-                                frequencyData <-
-                                  getByteFrequencyData a
+                                frequencyData <- getByteFrequencyData a
                                 arr <- toArray frequencyData
                                 push $ AsciiMixer $
                                   intercalate "\n"

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -5,7 +5,6 @@ import Prelude
 import Control.Alt (alt, (<|>))
 import Control.Monad.ST.Class (liftST)
 import Control.Monad.ST.Internal as RRef
-import Control.Plus (empty)
 import Data.Array ((..))
 import Data.ArrayBuffer.Typed (toArray)
 import Data.Foldable (for_, intercalate, fold)
@@ -28,7 +27,7 @@ import FRP.Behavior (sample_)
 import FRP.Event (Event, create, filterMap, hot, sampleOnRight, subscribe)
 import FRP.Event.Animate (animationFrameEvent)
 import Ocarina.Clock (WriteHead, fot, writeHead)
-import Ocarina.Control (analyser, gain, loopBuf, speaker2)
+import Ocarina.Control (analyser_, gain_, loopBuf, speaker2)
 import Ocarina.Core (Audible, bangOn, opticN)
 import Ocarina.Example.Utils (RaiseCancellation)
 import Ocarina.Interpret (close, context, decodeAudioDataFromUri, effectfulAudioInterpret, getByteFrequencyData, makeFFIAudioSnapshot)
@@ -45,16 +44,16 @@ scene atar cb wh =
   let
     tr = fot wh (mul pi)
   in
-    analyser { cb } empty
-      [ gain 1.0 empty
-          [ gain 0.3 empty
+    analyser_ { cb }
+      [ gain_ 1.0
+          [ gain_ 0.3
               [ loopBuf { buffer: atar, playbackRate: 1.0 }
                   ( bangOn <|>
                       playbackRate <<<
                         over opticN (\rad -> 1.0 + 0.1 * sin rad) <$> tr
                   )
               ]
-          , gain 0.15 empty
+          , gain_ 0.15
               [ loopBuf { buffer: atar, playbackRate: 1.0 }
                   ( bangOn
                       <|>
@@ -70,7 +69,7 @@ scene atar cb wh =
                           <<< view opticN <$> tr
                   )
               ]
-          , gain 0.3 empty
+          , gain_ 0.3
               [ loopBuf { buffer: atar, playbackRate: 0.25 } bangOn ]
           ]
       ]

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -27,7 +27,7 @@ import Effect.Class (liftEffect)
 import FRP.Behavior (sample_)
 import FRP.Event (Event, create, filterMap, hot, sampleOnRight, subscribe)
 import FRP.Event.Animate (animationFrameEvent)
-import Ocarina.Clock(WriteHead, fot, writeHead)
+import Ocarina.Clock (WriteHead, fot, writeHead)
 import Ocarina.Control (analyser, gain, loopBuf, speaker2)
 import Ocarina.Core (Audible, bangOn, opticN)
 import Ocarina.Example.Utils (RaiseCancellation)
@@ -51,7 +51,7 @@ scene atar cb wh =
               [ loopBuf { buffer: atar, playbackRate: 1.0 }
                   ( bangOn <|>
                       playbackRate <<<
-                        (over opticN (\rad -> 1.0 + 0.1 * sin rad)) <$> tr
+                        over opticN (\rad -> 1.0 + 0.1 * sin rad) <$> tr
                   )
               ]
           , gain 0.15 empty
@@ -59,7 +59,7 @@ scene atar cb wh =
                   ( bangOn
                       <|>
                         playbackRate <<<
-                          (over opticN (\rad -> 1.5 + 0.1 * sin (2.0 * rad)))
+                          over opticN (\rad -> 1.5 + 0.1 * sin (2.0 * rad))
                           <$> tr
                       <|>
                         loopStart <<< (\rad -> 0.1 + 0.1 * sin rad)
@@ -137,7 +137,7 @@ atariSpeaks atar rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
                                         ( \ii ->
                                             fold
                                               ( ( 0 ..
-                                                    (toInt ii)
+                                                    toInt ii
                                                 ) $> ">"
                                               )
 

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -40,21 +40,21 @@ scene
   -> AnalyserNodeCb
   -> WriteHead Event
   -> Audible D2 payload
-scene atari cb wh =
+scene buffer cb wh =
   let
     tr = fot wh (mul pi)
   in
     analyser_ { cb }
       [ gain_ 1.0
           [ gain_ 0.3
-              [ loopBuf { buffer: atari, playbackRate: 1.0 }
+              [ loopBuf { buffer, playbackRate: 1.0 }
                   ( bangOn <|>
                       playbackRate <<<
                         over opticN (\rad -> 1.0 + 0.1 * sin rad) <$> tr
                   )
               ]
           , gain_ 0.15
-              [ loopBuf { buffer: atari, playbackRate: 1.0 }
+              [ loopBuf { buffer, playbackRate: 1.0 }
                   ( bangOn
                       <|>
                         playbackRate <<<
@@ -69,8 +69,7 @@ scene atari cb wh =
                           <<< view opticN <$> tr
                   )
               ]
-          , gain_ 0.3
-              [ loopBuf { buffer: atari, playbackRate: 0.25 } bangOn ]
+          , gain_ 0.3 [ loopBuf { buffer, playbackRate: 0.25 } bangOn ]
           ]
       ]
 
@@ -82,10 +81,10 @@ data UIAction
 type Init = BrowserAudioBuffer
 
 initializeAtariSpeaks :: Aff Init
-initializeAtariSpeaks = do
-  atari <- liftEffect context >>= flip decodeAudioDataFromUri
-    "https://freesound.org/data/previews/100/100981_1234256-lq.mp3"
-  pure atari
+initializeAtariSpeaks =
+  liftEffect context
+    >>= flip decodeAudioDataFromUri
+      "https://freesound.org/data/previews/100/100981_1234256-lq.mp3"
 
 atariSpeaks
   :: BrowserAudioBuffer
@@ -178,5 +177,5 @@ atariSpeaks atari rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
 
 main :: Effect Unit
 main = launchAff_ do
-  atar <- initializeAtariSpeaks
-  liftEffect $ runInBody (atariSpeaks atar (const $ pure unit))
+  atari <- initializeAtariSpeaks
+  liftEffect $ runInBody (atariSpeaks atari (const $ pure unit))

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -128,12 +128,8 @@ atariSpeaks atari rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
                               for_ analyser \a -> do
                                 frequencyData <- getByteFrequencyData a
                                 arr <- toArray frequencyData
-                                push $ AsciiMixer $
-                                  intercalate "\n"
-                                    ( map
-                                        (\ii -> fold ((0 .. toInt ii) $> ">"))
-                                        arr
-                                    )
+                                push $ AsciiMixer $ intercalate "\n" $
+                                  map (\ii -> fold ((0 .. toInt ii) $> ">")) arr
                           )
                         let unsub = unsub' *> afe.unsubscribe
                         rc $ Just { unsub, ctx }

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -132,14 +132,7 @@ atariSpeaks atari rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
                                 push $ AsciiMixer $
                                   intercalate "\n"
                                     ( map
-                                        ( \ii ->
-                                            fold
-                                              ( ( 0 ..
-                                                    toInt ii
-                                                ) $> ">"
-                                              )
-
-                                        )
+                                        (\ii -> fold ((0 .. toInt ii) $> ">"))
                                         arr
                                     )
                           )

--- a/examples/atari-speaks/AtariSpeaks.purs
+++ b/examples/atari-speaks/AtariSpeaks.purs
@@ -40,21 +40,21 @@ scene
   -> AnalyserNodeCb
   -> WriteHead Event
   -> Audible D2 payload
-scene atar cb wh =
+scene atari cb wh =
   let
     tr = fot wh (mul pi)
   in
     analyser_ { cb }
       [ gain_ 1.0
           [ gain_ 0.3
-              [ loopBuf { buffer: atar, playbackRate: 1.0 }
+              [ loopBuf { buffer: atari, playbackRate: 1.0 }
                   ( bangOn <|>
                       playbackRate <<<
                         over opticN (\rad -> 1.0 + 0.1 * sin rad) <$> tr
                   )
               ]
           , gain_ 0.15
-              [ loopBuf { buffer: atar, playbackRate: 1.0 }
+              [ loopBuf { buffer: atari, playbackRate: 1.0 }
                   ( bangOn
                       <|>
                         playbackRate <<<
@@ -70,7 +70,7 @@ scene atar cb wh =
                   )
               ]
           , gain_ 0.3
-              [ loopBuf { buffer: atar, playbackRate: 0.25 } bangOn ]
+              [ loopBuf { buffer: atari, playbackRate: 0.25 } bangOn ]
           ]
       ]
 
@@ -83,15 +83,15 @@ type Init = BrowserAudioBuffer
 
 initializeAtariSpeaks :: Aff Init
 initializeAtariSpeaks = do
-  atar <- liftEffect context >>= flip decodeAudioDataFromUri
+  atari <- liftEffect context >>= flip decodeAudioDataFromUri
     "https://freesound.org/data/previews/100/100981_1234256-lq.mp3"
-  pure atar
+  pure atari
 
 atariSpeaks
   :: BrowserAudioBuffer
   -> RaiseCancellation
   -> Nut
-atariSpeaks atar rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
+atariSpeaks atari rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
   DOM.div_
     [ DOM.h1_ [ text_ "Atari speaks" ]
     , DOM.button
@@ -108,7 +108,7 @@ atariSpeaks atar rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
                         let wh = writeHead 0.04 ctx
                         let
                           audioE = speaker2
-                            [ scene atar
+                            [ scene atari
                                 ( AnalyserNodeCb
                                     ( \a -> do
                                         analyserE.push (Just a)
@@ -162,14 +162,14 @@ atariSpeaks atar rc = bussed \push -> lcmap (alt (pure TurnOn)) \event ->
             )
         ]
         [ text
-            ( event # map case _ of
+            ( event <#> case _ of
                 TurnOn -> "Turn on"
                 _ -> "Turn off"
             )
         ]
     , DOM.p_
         [ text
-            ( event # map case _ of
+            ( event <#> case _ of
                 AsciiMixer s -> s
                 _ -> ""
             )


### PR DESCRIPTION
This PR intend to make the example a bit more readable by using _ versions of functions and improve formating